### PR TITLE
Plotman doesn't work if using the gui install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 venv
+src/plotman.egg-info/

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -90,3 +90,4 @@ class PlotmanConfig:
     directories: Directories
     scheduling: Scheduling
     plotting: Plotting
+    gui_install: bool


### PR DESCRIPTION
### Plotman doesn't work if using the gui install

Plotman can't find running jobs if installed with the experimental gui option.

+ Adds a flag to the config file that to let plotman know if it was installed with the experimental gui installer
+ Modifying `jobs.py` to search for running jobs differently if the flag is set

### Testing (?)

Not sure preferred way of testing. Please let me know.